### PR TITLE
rf: server stash saving (avoid duplicates and multiple registering)

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -1,53 +1,46 @@
 for k, v in ipairs(Config.BoxLocations) do
-    local modelHash = Config.Model -- The prop
-
-    if not HasModelLoaded(modelHash) then -- Checking if the model loaded, if it didn't, it waits
-        RequestModel(modelHash)
-
-        while not HasModelLoaded(modelHash) do
-            Citizen.Wait(1)
-        end
-    end
-
-    local model = CreateObject(modelHash, v.coords.x, v.coords.y, v.coords.z - 1, v.coords.w) -- Creating the prop once loaded
-    FreezeEntityPosition(model, true) -- Freezing it at the location
-
-    TriggerServerEvent('yettieEvidenceBox:registerStashes', k, vector3(v.coords.x, v.coords.y, v.coords.z - 1)) -- Registers the box with its ID
-
-    --
-    --- Register the net event for opening the stash
-    --
-
-    RegisterNetEvent('yettiEvidenceBox:openStash', function(numb)
-        exports.ox_inventory:openInventory('stash', 'CPZ' .. numb)
-    end)
-
-    RegisterCommand('++openCpzBox' .. k, function ()
-        exports.ox_inventory:openInventory('stash', 'CPZ' .. k)
-    end)
-
-    --
-    --- Add a target box zone for the stash
-    --
-    exports.ox_target:addBoxZone({
-        coords = vector3(v.coords.x, v.coords.y, v.coords.z - 1),
-        size = vector3(1.2, 1.2, 3.0),
-        rotation = 0.0,
+    lib.zones.sphere({
+        coords = v.coords,
+        radius = Config.DisplayDistance,
         debug = Config.Debug,
-        options = {
-            {
-                type = "client",
-                command = '++openCpzBox' .. k,
-                icon = Config.TargetIcon,
-                label = Config.TargetLabel:format(k),
-                distance = Config.TargetDistance,
-                groups = Config.AccessJobs
-            }
-        }
+        modelEntity = nil,
+        targetID = nil,
+        stashName = 'CPZ' .. k,
+        onEnter = function (self)
+            local modelHash, stashName = Config.Model, self.stashName
+
+            lib.requestModel(modelHash)
+
+            local model = CreateObject(modelHash, v.coords.x, v.coords.y, v.coords.z - 1, v.coords.w, false) -- Creating the prop once loaded
+            FreezeEntityPosition(model, true)
+
+            self.modelEntity = model
+
+            self.targetID = exports.ox_target:addBoxZone({
+                coords = vector3(self.coords.x, self.coords.y, self.coords.z - 1),
+                size = vector3(1.2, 1.2, 3.0),
+                rotation = 0.0,
+                debug = Config.Debug,
+                options = {
+                    {
+                        onSelect = function (data)
+                            exports.ox_inventory:openInventory('stash', stashName)
+                        end,
+                        icon = Config.TargetIcon,
+                        label = Config.TargetLabel:format(k),
+                        distance = Config.TargetDistance,
+                        groups = Config.AccessJobs
+                    }
+                }
+            })
+        end,
+        onExit = function (self)
+            DeleteEntity(self.modelEntity)
+            exports.ox_target:removeZone(self.targetID)
+            SetModelAsNoLongerNeeded(Config.Model)
+            SetEntityAsNoLongerNeeded(self.modelEntity)
+            self.modelEntity = nil
+        end
     })
-
-
-
-
 end
 

--- a/config.lua
+++ b/config.lua
@@ -4,6 +4,8 @@ Config.Debug = false -- Toggle debug - true / false
 
 Config.Model = `v_res_filebox01` -- The model of the evidence box
 
+Config.DisplayDistance = 50
+
 Config.BoxLocations = { -- Where the boxes are created at
    [1] = { coords = vector4(462.2334, -1003.0744, 24.9148, 270.2914) },
    [2] = { coords = vector4(462.3722, -999.7912, 24.9149, 270.2914) },

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,15 +5,15 @@ lua54 'yes'
 author 'Yetti Development'
 description 'Evidence boxes for police.'
 
+shared_scripts {
+    "config.lua",
+    '@ox_lib/init.lua',
+}
+
 client_scripts {
     "client/client.lua",
 }
 
 server_scripts {
     'server/server.lua'
-}
-
-shared_scripts {
-    "config.lua",
-    '@ox_lib/init.lua',
 }

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,8 +1,8 @@
-RegisterNetEvent('yettieEvidenceBox:registerStashes', function (stashid, stashcoords)
-
+for k, v in ipairs(Config.BoxLocations) do
+    local stashid, stashcoords = k, vector3(v.coords.x, v.coords.y, v.coords.z - 1)
     exports.ox_inventory:RegisterStash('CPZ' .. stashid, Config.StashLabel:format(stashid), Config.StashSlots, Config.StashWeight, nil, nil, stashcoords)
 
     if Config.Debug then
         print('Registering stash with id: CPZ' .. stashid)
     end
-end)
+end


### PR DESCRIPTION
Fixes:
- Box's are only generated in a specific distance
- Box's are no longer networked
- Moved the stash register to execute 1 and not on every user connection

Refactors:
- moved shared scripts to top of the manifest